### PR TITLE
Created a configuration setting to only show ants for actions your ch…

### DIFF
--- a/AbilityAntsPlugin/AbilityAnts.cs
+++ b/AbilityAntsPlugin/AbilityAnts.cs
@@ -7,16 +7,12 @@ using Dalamud.Hooking;
 using Dalamud.IoC;
 using Dalamud.Plugin;
 using FFXIVClientStructs.FFXIV.Client.Game;
-using Lumina.Excel.GeneratedSheets;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Runtime;
 using System.Runtime.InteropServices;
 using Action = Lumina.Excel.GeneratedSheets.Action;
+using Dalamud.Logging;
 
 namespace AbilityAntsPlugin
 {
@@ -145,8 +141,13 @@ namespace AbilityAntsPlugin
                 float recastElapsed = AM->GetRecastTimeElapsed(at, actionID);
                 var maxCharges = ActionManager.GetMaxCharges((uint)actionID, ClientState.LocalPlayer.Level);
 
+                if (Configuration.ShowOnlyUsableActions && 
+                    action.ClassJobLevel > ClientState.LocalPlayer.Level)
+                    return false;
+
                 if (!recastActive && maxCharges == 0)
                     return true;
+
                 if (maxCharges > 0)
                 {                     
                     if (!Configuration.AntOnFinalStack)

--- a/AbilityAntsPlugin/AbilityAntsAddressResolver.cs
+++ b/AbilityAntsPlugin/AbilityAntsAddressResolver.cs
@@ -1,9 +1,5 @@
 ﻿using Dalamud.Game;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace AbilityAntsPlugin
 {

--- a/AbilityAntsPlugin/AbilityAntsUI.cs
+++ b/AbilityAntsPlugin/AbilityAntsUI.cs
@@ -1,10 +1,5 @@
 ﻿using AbilityAnts;
-using Dalamud.Data;
 using ImGuiNET;
-using ImGuiScene;
-using Lumina.Data;
-using Lumina.Excel;
-using Lumina;
 using Lumina.Excel.GeneratedSheets;
 using System;
 using System.Collections.Generic;
@@ -14,7 +9,7 @@ using Action = Lumina.Excel.GeneratedSheets.Action;
 using Dalamud.Interface.Internal;
 
 namespace AbilityAntsPlugin
-{ 
+{
     // It is good to have this be disposable in general, in case you ever need it
     // to do any cleanup
     class AbilityAntsUI : IDisposable
@@ -110,7 +105,14 @@ namespace AbilityAntsPlugin
                     Configuration.ShowOnlyInCombat = showCombat;
                     Configuration.Save();
                 }
-                
+
+                bool showUsable = Configuration.ShowOnlyUsableActions;
+                if (ImGui.Checkbox("Only show custom ants for actions your character can use (job level restriction).", ref showUsable))
+                {
+                    Configuration.ShowOnlyUsableActions = showUsable;
+                    Configuration.Save();
+                }
+
                 bool lastCharge = Configuration.AntOnFinalStack;
                 if (ImGui.Checkbox("Charged abilities only get ants for the final charge", ref lastCharge))
                 {

--- a/AbilityAntsPlugin/Configuration.cs
+++ b/AbilityAntsPlugin/Configuration.cs
@@ -12,6 +12,7 @@ namespace AbilityAntsPlugin
         public int PreAntTimeMs { get; set; } = 3000;
         public bool ShowOnlyInCombat { get; set; } = true;
         public bool AntOnFinalStack { get; set; } = true;
+        public bool ShowOnlyUsableActions { get; set; } = false;
         public Dictionary<uint, int> ActiveActions { get; private set; }
 
         // the below exist just to make saving less cumbersome

--- a/AbilityAntsPlugin/Services.cs
+++ b/AbilityAntsPlugin/Services.cs
@@ -1,16 +1,7 @@
-﻿using Dalamud.Data;
-using Dalamud.Game;
+﻿using Dalamud.Game;
 using Dalamud.Plugin.Services;
-using Dalamud.Game.ClientState;
-using Dalamud.Game.ClientState.Conditions;
-using Dalamud.Game.Command;
 using Dalamud.IoC;
 using Dalamud.Plugin;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace AbilityAnts
 {


### PR DESCRIPTION
…aracter can actually use on their current job level.

This should prevent ants from cluttering the screen when they cant even be used due to a duty level-syncing.